### PR TITLE
disable automount when cloning

### DIFF
--- a/dump.sh
+++ b/dump.sh
@@ -51,8 +51,7 @@ if zfs get name "$working_dataset"; then
     exit 1
 fi
 
-# || true -> we can't mount it, so it'll exit 1
-zfs clone "$src_snap" "$working_dataset" || true
+zfs clone -o canmount=noauto "$src_snap" "$working_dataset"
 if ! zfs get name "$working_dataset"; then
     echo "target does not exist, aborting"
     exit 1


### PR DESCRIPTION
This should avoid the mount failure since zfs won't try to mount it
automaticaly anymore.