### PR TITLE
add a schema dump

### DIFF
--- a/dump.sh
+++ b/dump.sh
@@ -98,6 +98,10 @@ pg_dump hydra \
         --create --format=directory --exclude-table users --verbose \
         -U hydra --host "$socket" -f ./backup.dump
 
+echo "starting schema dump"
+pg_dump hydra --schema-only \
+        -U hydra --host "$socket" -f ./schema.sql
+
 echo "creating partial tables"
 psql hydra -U hydra --host "$socket" < copy.sql
 


### PR DESCRIPTION
Since the partial export creates new tables it doesn't include any of
the constraints or indexes.  While this is less data it's still more
than enough to make indexes useful.